### PR TITLE
Copy wrapped border bug

### DIFF
--- a/src/EncinoWaves/MipMap.h
+++ b/src/EncinoWaves/MipMap.h
@@ -186,12 +186,7 @@ void Downsample(const RealSpatialField2D<T>& i_src,
   }
 
   // Fill in the repeated border.
-  {
-    CopyWrappedBorder<T> F;
-    F.Data = o_dst.data();
-    F.N = o_dst.unpaddedWidth();
-    tbb::parallel_for(tbb::blocked_range<int>{0, (int)o_dst.height()}, F);
-  }
+  CopyWrappedBorder(o_dst);
 }
 
 //-*****************************************************************************


### PR DESCRIPTION
There was a bug in the way that wrapped border values were being copied. Essentially, it is necessary to make sure that the first row has had its border (padding) values copied to before setting the entire last row to be equal to the first. The way it was being done lead to cases where the first row was copied into the last before the first row had been "completed". This bug showed up intermittently, because it depends on the order in which TBB chooses to run the sub-ranges. 

I made an example showing how the new algorithm works: [https://godbolt.org/z/qcoEEvsKn](https://godbolt.org/z/qcoEEvsKn)

The only difference is to explicitly copy the first row into the last row after all the "non-last" rows have been completed.
